### PR TITLE
Fix build warnings and upgrade AWS SDK to v4

### DIFF
--- a/ThirdOpinion.Common.Aws.Cognito/AuthorizeTenantGuidAttribute.cs
+++ b/ThirdOpinion.Common.Aws.Cognito/AuthorizeTenantGuidAttribute.cs
@@ -10,12 +10,12 @@ namespace ThirdOpinion.Common.Cognito;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
 public class AuthorizeTenantGuidAttribute : ValidationAttribute
 {
-    protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
     {
-        var httpContextAccessor = (IHttpContextAccessor)validationContext
-            .GetService(typeof(IHttpContextAccessor));
-        var options = (IOptions<GlobalAppSettingsOptions>)validationContext
-            .GetService(typeof(IOptions<GlobalAppSettingsOptions>));
+        var httpContextAccessor = validationContext
+            .GetService(typeof(IHttpContextAccessor)) as IHttpContextAccessor;
+        var options = validationContext
+            .GetService(typeof(IOptions<GlobalAppSettingsOptions>)) as IOptions<GlobalAppSettingsOptions>;
 
         if (httpContextAccessor?.HttpContext?.User?.Identity?.IsAuthenticated != true)
             return new ValidationResult("User is not authenticated");
@@ -26,7 +26,8 @@ public class AuthorizeTenantGuidAttribute : ValidationAttribute
         if (groups == null) return new ValidationResult("User does not have a groups claim");
 
         // Get the value of the property being validated
-        var propertyGuid = (Guid)value;
+        if (value == null || !(value is Guid propertyGuid))
+            return new ValidationResult("Value must be a valid Guid");
 
         //look in config for the tenantGuid
         List<string>? tenantGroups = null;

--- a/ThirdOpinion.Common.Aws.DynamoDb/DynamoDbRepository.cs
+++ b/ThirdOpinion.Common.Aws.DynamoDb/DynamoDbRepository.cs
@@ -44,7 +44,7 @@ public class DynamoDbRepository : IDynamoDbRepository
     {
         try
         {
-            BatchWrite<T>? batch = _context.CreateBatchWrite<T>();
+            var batch = _context.CreateBatchWrite<T>();
             foreach (T entity in entities) batch.AddPutItem(entity);
             await batch.ExecuteAsync(cancellationToken);
             _logger.LogDebug("Batch saved {Count} entities of type {EntityType} to DynamoDB",
@@ -105,7 +105,7 @@ public class DynamoDbRepository : IDynamoDbRepository
     {
         try
         {
-            AsyncSearch<T> query;
+            IAsyncSearch<T> query;
 
             if (filter != null)
             {
@@ -155,8 +155,8 @@ public class DynamoDbRepository : IDynamoDbRepository
             {
                 Items = items,
                 LastEvaluatedKey = response.LastEvaluatedKey,
-                Count = response.Count,
-                ScannedCount = response.ScannedCount
+                Count = response.Count ?? 0,
+                ScannedCount = response.ScannedCount ?? 0
             };
         }
         catch (Exception ex)
@@ -171,7 +171,7 @@ public class DynamoDbRepository : IDynamoDbRepository
     {
         try
         {
-            AsyncSearch<T> scan;
+            IAsyncSearch<T> scan;
 
             if (filter != null)
             {

--- a/ThirdOpinion.Common.Aws.DynamoDb/ThirdOpinion.Common.Aws.DynamoDb.csproj
+++ b/ThirdOpinion.Common.Aws.DynamoDb/ThirdOpinion.Common.Aws.DynamoDb.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.401.7" />
+        <PackageReference Include="AWSSDK.DynamoDBv2" Version="4.0.3.4" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />

--- a/ThirdOpinion.Common.Aws.DynamoDb/TypeConverters/EnumTypeConverter.cs
+++ b/ThirdOpinion.Common.Aws.DynamoDb/TypeConverters/EnumTypeConverter.cs
@@ -23,7 +23,7 @@ public class EnumConverter<T> : IPropertyConverter where T : struct, Enum
         throw new ArgumentException("Value must be an enum or null");
     }
 
-    public object FromEntry(DynamoDBEntry entry)
+    public object? FromEntry(DynamoDBEntry entry)
     {
         var primitive = entry as Primitive;
 
@@ -59,20 +59,20 @@ public class NullableEnumConverter<T> : IPropertyConverter where T : struct, Enu
             var hasValueProperty = nullableType.GetProperty("HasValue");
             var valueProperty = nullableType.GetProperty("Value");
 
-            var hasValue = (bool)hasValueProperty.GetValue(value);
+            var hasValue = (bool)(hasValueProperty?.GetValue(value) ?? false);
             if (!hasValue)
                 return new Primitive { Value = null };
 
             // Get the actual enum value
-            var enumValue = valueProperty.GetValue(value);
-            return _enumConverter.ToEntry(enumValue);
+            var enumValue = valueProperty?.GetValue(value);
+            return enumValue != null ? _enumConverter.ToEntry(enumValue) : new Primitive { Value = null };
         }
 
         // Fall back to regular converter
         return _enumConverter.ToEntry(value);
     }
 
-    public object FromEntry(DynamoDBEntry entry)
+    public object? FromEntry(DynamoDBEntry entry)
     {
         var result = _enumConverter.FromEntry(entry);
         if (result == null)

--- a/ThirdOpinion.Common.Aws.S3/S3Storage.cs
+++ b/ThirdOpinion.Common.Aws.S3/S3Storage.cs
@@ -207,7 +207,7 @@ public class S3Storage : IS3Storage
                 response = await _s3Client.ListObjectsV2Async(request, cancellationToken);
                 allObjects.AddRange(response.S3Objects);
                 request.ContinuationToken = response.NextContinuationToken;
-            } while (response.IsTruncated);
+            } while (response.IsTruncated ?? false);
 
             _logger.LogDebug("Listed {Count} objects from S3 bucket {Bucket} with prefix {Prefix}",
                 allObjects.Count, bucketName, prefix);

--- a/ThirdOpinion.Common.Aws.S3/ThirdOpinion.Common.Aws.S3.csproj
+++ b/ThirdOpinion.Common.Aws.S3/ThirdOpinion.Common.Aws.S3.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.401.7"/>
+        <PackageReference Include="AWSSDK.S3" Version="4.0.4"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>

--- a/ThirdOpinion.Common.Aws.SQS/ThirdOpinion.Common.Aws.SQS.csproj
+++ b/ThirdOpinion.Common.Aws.SQS/ThirdOpinion.Common.Aws.SQS.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.Core" Version="3.7.400.63"/>
-        <PackageReference Include="AWSSDK.SQS" Version="3.7.400.63"/>
+        <PackageReference Include="AWSSDK.Core" Version="4.0.0.23"/>
+        <PackageReference Include="AWSSDK.SQS" Version="4.0.0.21"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2"/>

--- a/ThirdOpinion.Common.UnitTests/ThirdOpinion.Common.UnitTests.csproj
+++ b/ThirdOpinion.Common.UnitTests/ThirdOpinion.Common.UnitTests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-        <PackageReference Include="AWSSDK.Core" Version="4.0.0.21" />
+        <PackageReference Include="AWSSDK.Core" Version="4.0.0.23" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
     </ItemGroup>


### PR DESCRIPTION
## Summary
- Fixed all build warnings (0 warnings, 0 errors)
- Upgraded AWS SDK packages from v3 to v4 for consistency across the solution
- Fixed nullable reference type warnings in multiple files

## Changes

### Package Upgrades
- AWSSDK.Core → 4.0.0.23
- AWSSDK.DynamoDBv2 → 4.0.3.4
- AWSSDK.S3 → 4.0.4
- AWSSDK.SQS → 4.0.0.21

### Code Fixes
- **EnumTypeConverter**: Added null checks and changed return types to nullable
- **DynamoDbRepository**: Added null coalescing for Count properties and updated to use interfaces (IAsyncSearch, IBatchWrite)
- **AuthorizeTenantGuidAttribute**: Fixed nullable parameter types and safe casting
- **S3Storage**: Fixed IsTruncated nullable bool check

## Test Results
✅ All 234 unit tests passing
✅ Build succeeds with 0 warnings and 0 errors

🤖 Generated with [Claude Code](https://claude.ai/code)